### PR TITLE
Closing the file stops a double-free crash UoS is seeing

### DIFF
--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -438,6 +438,9 @@ void Analyzer::setupCR(std::string var, double val) {
 
 ////destructor
 Analyzer::~Analyzer() {
+  routfile->Write();
+  routfile->Close();
+
   clear_values();
   delete BOOM;
   delete _Electron;


### PR DESCRIPTION
Hi, the University of Seoul analyzers are seeing a crash at the end of running. This crash is avoided if the output file is closed before the rest of the cleanup occurs in the destructor (seems to be due to a double-free that the file tries to do in the cleanup phase after the program exits). Nb. I tested this only on a single MC file.

@jshlee
