### PR TITLE
updated electron branch names, treat muons as neutrinos & z-boost weights systematics.

### DIFF
--- a/PartDet/Electron_info.in
+++ b/PartDet/Electron_info.in
@@ -32,15 +32,13 @@ IsoSumPtCutValue 0.0 0.15
 //(0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
 DoDiscrByCBID true
 DiscrByCBID 4
-DoDiscrByHLTID false
-DiscrByHLTID 4
-DoDiscrByHEEPID false
 
-// DoDiscrByVetoID false
-// DoDiscrByLooseID false
-// DoDiscrByMediumID false
-// DoDiscrByTightID true
-// DoDiscrByHEEPID false
+DoDiscrBymvaID false
+DiscrBymvaWP80 0
+DiscrBymvaWP90 1
+DiscrBymvaWPL  0
+
+DoDiscrByHEEPID false
 
 ///---MET TOPOLOGY CUTS---///
 
@@ -64,17 +62,15 @@ PtCut 20.0 9999.9
 DoDiscrByIsolation 1
 IsoSumPtCutValue 0.1 0.2
 
-// DoDiscrByVetoID false
-// DoDiscrByLooseID true
-// DoDiscrByMediumID 0
-// DoDiscrByTightID false
-// DoDiscrByHEEPID 0
-
 //(0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
 DoDiscrByCBID true
 DiscrByCBID 4
-DoDiscrByHLTID false
-DiscrByHLTID 4
+
+DoDiscrBymvaID false
+DiscrBymvaWP80 0
+DiscrBymvaWP90 1
+DiscrBymvaWPL  0
+
 DoDiscrByHEEPID false
 
 ///---MET TOPOLOGY CUTS---///

--- a/PartDet/Run_info.in
+++ b/PartDet/Run_info.in
@@ -46,6 +46,7 @@ UseTriggerWildcard false
 ///---Treat Muon as Neutrino---///
 
 TreatMuonsAsNeutrinos 0
+TreatOnlyOneMuonAsNeutrino 0
 TreatMuonsAsTaus 0
 
 ///-----MET cuts------///

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -2475,7 +2475,8 @@ void Analyzer::getGoodRecoLeptons(const Lepton& lep, const CUTS ePos, const CUTS
       }
       ////electron cuts
       else if(lep.type == PType::Electron){
-	//std::cout << "got an electron to check..." << std::endl;
+	     //std::cout << "got an electron to check..." << std::endl;
+        /*
         if(cut == "DoDiscrByHLTID"){
           std::bitset<8> idvariable(_Electron->cutBased_HLTPreSel[i]);
           if(ival(ePos) - ival(CUTS::eRElec2)){ //test if it is electron1
@@ -2485,21 +2486,29 @@ void Analyzer::getGoodRecoLeptons(const Lepton& lep, const CUTS ePos, const CUTS
             passCuts = passCuts && (_Electron->cbHLTIDele2&idvariable).count();
           }
         }
+        */
         if(cut == "DoDiscrByCBID"){
-	  //std::cout << "cutBased[i]: " << (_Electron->cutBased[i]) << std::endl;
+	        //std::cout << "cutBased[i]: " << (_Electron->cutBased[i]) << std::endl;
           std::bitset<8> idvariable(_Electron->cutBased[i]);
-	  //std::cout << "ival(ePos): " << ival(ePos) << std::endl;
-	  //std::cout << "ival(CUTS::eRElec2): " << ival(CUTS::eRElec2) << std::endl;
+          //std::cout << "ival(ePos): " << ival(ePos) << std::endl;
+          //std::cout << "ival(CUTS::eRElec2): " << ival(CUTS::eRElec2) << std::endl;
           if(ival(ePos) - ival(CUTS::eRElec2)){ //test if it is electron1
-	    //std::cout << "cbIDele1: " << (_Electron->cbIDele1) << std::endl;
-	    //std::cout << "idvariable: " << (idvariable) << std::endl;
-	    //std::cout << "the AND: " << (_Electron->cbIDele1&idvariable) << std::endl;
+            //std::cout << "cbIDele1: " << (_Electron->cbIDele1) << std::endl;
+            //std::cout << "idvariable: " << (idvariable) << std::endl;
+            //std::cout << "the AND: " << (_Electron->cbIDele1&idvariable) << std::endl;
             passCuts = passCuts && (_Electron->cbIDele1&idvariable).count();
-	    //std::cout << "it's an elec1..." << std::endl;
-	    //std::cout << "passCuts value2: " << passCuts << std::endl;
+            //std::cout << "it's an elec1..." << std::endl;
+            //std::cout << "passCuts value2: " << passCuts << std::endl;
           }else{
             passCuts = passCuts && (_Electron->cbIDele2&idvariable).count();
           }
+        }
+        else if(cut == "DoDiscrBymvaID"){
+          if(stats.bfind("DiscrBymvaWP80")) passCuts = passCuts && _Electron->mvaFall17V2Iso_WP80[i];
+          
+          else if(stats.bfind("DiscrBymvaWP90")) passCuts = passCuts && _Electron->mvaFall17V2Iso_WP90[i];
+          
+          else if(stats.bfind("DiscrBymvaWPL")) passCuts = passCuts && _Electron->mvaFall17V2Iso_WPL[i];
         }
         else if(cut == "DoDiscrByHEEPID")
          passCuts = passCuts && _Electron->isPassHEEPId[i];

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -3501,6 +3501,53 @@ double Analyzer::getZBoostWeight(){
   return boostweigth;
 }
 
+double Analyzer::getZBoostWeightSyst(int ud){
+  double boostweigth=1.;
+  if((active_part->at(CUTS::eGElec)->size() + active_part->at(CUTS::eGTau)->size() + active_part->at(CUTS::eGMuon)->size()) >=1 && (active_part->at(CUTS::eGZ)->size() ==1 || active_part->at(CUTS::eGW)->s\
+ize() ==1)){
+    double boostz = 0;
+    if(active_part->at(CUTS::eGZ)->size() ==1){
+      boostz = _Gen->pt(active_part->at(CUTS::eGZ)->at(0));
+    }
+    if(active_part->at(CUTS::eGW)->size() ==1){
+      boostz = _Gen->pt(active_part->at(CUTS::eGW)->at(0));
+    }
+    if (ud == 0){
+      if(boostz > 0 && boostz <= 50) {boostweigth = 1.1192;}// 1.0942, 1.1192, 1.1442 5.26                                                                                                                  
+      else if (boostz > 50 && boostz <= 100) {boostweigth = 1.1034;}// 1.0901, 1.1034, 1.1167                                                                                                               
+      else if (boostz > 100 && boostz <= 150) {boostweigth = 1.0675;}// 1.0559, 1.0675, 1.0791                                                                                                              
+      else if (boostz > 150 && boostz <= 200) {boostweigth = 1.0637;}// 1.0511, 1.0637, 1.0763                                                                                                              
+      else if (boostz > 200 && boostz <= 300) {boostweigth = 1.0242;}// 1.011, 1.0242, 1.0374                                                                                                               
+      else if (boostz > 300 && boostz <= 400) {boostweigth = 0.9453;}// 0.9269, 0.9453, 0.9637                                                                                                              
+      else if (boostz > 400 && boostz <= 600) {boostweigth = 0.8579;}// 0.8302, 0.8579, 0.8856                                                                                                              
+      else if (boostz >= 600) {boostweigth = 0.7822;}// 0.6692, 0.7822, 0.8952                                                                                                                              
+      else {boostweigth = 1;}}
+
+    else if (ud == -1){
+      if(boostz > 0 && boostz <= 50) {boostweigth = 1.0942;}// 1.0942, 1.1192, 1.1442 5.26                                                                                                                  
+      else if (boostz > 50 && boostz <= 100) {boostweigth = 1.0901;}// 1.0901, 1.1034, 1.1167                                                                                                               
+      else if (boostz > 100 && boostz <= 150) {boostweigth = 1.0559;}// 1.0559, 1.0675, 1.0791                                                                                                              
+      else if (boostz > 150 && boostz <= 200) {boostweigth = 1.0511;}// 1.0511, 1.0637, 1.0763                                                                                                              
+      else if (boostz > 200 && boostz <= 300) {boostweigth = 1.011;}// 1.011, 1.0242, 1.0374                                                                                                                
+      else if (boostz > 300 && boostz <= 400) {boostweigth = 0.9269;}// 0.9269, 0.9453, 0.9637                                                                                                              
+      else if (boostz > 400 && boostz <= 600) {boostweigth = 0.8302;}// 0.8302, 0.8579, 0.8856                                                                                                              
+      else if (boostz >= 600) {boostweigth = 0.6692;}// 0.6692, 0.7822, 0.8952                                                                                                                              
+      else {boostweigth = 1;}}
+
+    else if (ud == 1){
+      if(boostz > 0 && boostz <= 50) {boostweigth = 1.1442;}// 1.0942, 1.1192, 1.1442 5.26                                                                                                                  
+      else if (boostz > 50 && boostz <= 100) {boostweigth = 1.1167;}// 1.0901, 1.1034, 1.1167                                                                                                               
+      else if (boostz > 100 && boostz <= 150) {boostweigth = 1.0791;}// 1.0559, 1.0675, 1.0791                                                                                                              
+      else if (boostz > 150 && boostz <= 200) {boostweigth = 1.0763;}// 1.0511, 1.0637, 1.0763                                                                                                              
+      else if (boostz > 200 && boostz <= 300) {boostweigth = 1.0374;}// 1.011, 1.0242, 1.0374                                                                                                               
+      else if (boostz > 300 && boostz <= 400) {boostweigth = 0.9637;}// 0.9269, 0.9453, 0.9637                                                                                                              
+      else if (boostz > 400 && boostz <= 600) {boostweigth = 0.8856;}// 0.8302, 0.8579, 0.8856                                                                                                              
+      else if (boostz >= 600) {boostweigth = 0.8952;}// 0.6692, 0.7822, 0.8952                                                                                                                              
+      else {boostweigth = 1;}}
+
+  }
+  return boostweigth;
+}
 
 double Analyzer::getWkfactor(){
   double kfactor=1.;
@@ -3543,7 +3590,11 @@ void Analyzer::fill_histogram() {
     if(distats["Run"].bfind("ApplyTauIDSF")) wgt *= getTauDataMCScaleFactor(0);
 
     if(distats["Run"].bfind("ApplyZBoostSF") && isVSample){
-      wgt *= getZBoostWeight();
+      //wgt *= getZBoostWeight();
+      wgt *= getZBoostWeightSyst(0);
+      boosters[0] = getZBoostWeightSyst(0); //06.02.20                                                                                                                                                      
+      boosters[1] = getZBoostWeightSyst(-1);  //06.02.20                                                                                                                                                    
+      boosters[2] = getZBoostWeightSyst(1);  //06.02.20
     }
     if(distats["Run"].bfind("ApplyWKfactor")){
       wgt *= getWkfactor();
@@ -3596,13 +3647,29 @@ void Analyzer::fill_histogram() {
 
       if(syst_names[i].find("Btag")!=std::string::npos){ //01.16.19
         if(syst_names[i]=="Btag_Up"){
-	  wgt/=getBJetSF(CUTS::eRBJet, _Jet->pstats["BJet"]);
-	  wgt*=getBJetSFResUp(CUTS::eRBJet, _Jet->pstats["BJet"]);
+          wgt/=getBJetSF(CUTS::eRBJet, _Jet->pstats["BJet"]);
+          wgt*=getBJetSFResUp(CUTS::eRBJet, _Jet->pstats["BJet"]);
         }else if(syst_names[i]=="Btag_Down"){
-	  wgt/=getBJetSF(CUTS::eRBJet, _Jet->pstats["BJet"]);
+          wgt/=getBJetSF(CUTS::eRBJet, _Jet->pstats["BJet"]);
           wgt*=getBJetSFResDown(CUTS::eRBJet, _Jet->pstats["BJet"]);
         }
       }
+
+      ///---06.06.20---                                                                                                                                                                                     
+      if(syst_names[i].find("ISR_weight")!=std::string::npos){ //07.09.18                                                                                                                                   
+        if(syst_names[i]=="ISR_weight_up"){
+          if(distats["Run"].bfind("ApplyZBoostSF") && isVSample) {
+            wgt/=boosters[0];
+            wgt*=boosters[2];
+          }
+        }else if(syst_names[i]=="ISR_weight_down"){
+          if(distats["Run"].bfind("ApplyZBoostSF") && isVSample) {
+            wgt/=boosters[0];
+            wgt*=boosters[1];
+          }
+        }
+      }
+      ///---06.02.20 
 
       //get the non particle conditions:
       for(auto itCut : nonParticleCuts){

--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -2440,8 +2440,14 @@ void Analyzer::getGoodRecoLeptons(const Lepton& lep, const CUTS ePos, const CUTS
   int i = 0;
   for(auto lvec: lep) {
     bool passCuts = true;
-    if (fabs(lvec.Eta()) > stats.dmap.at("EtaCut")) passCuts = passCuts && false;
-    else if (lvec.Pt() < stats.pmap.at("PtCut").first || lvec.Pt() > stats.pmap.at("PtCut").second) passCuts = passCuts && false;
+    if (fabs(lvec.Eta()) > stats.dmap.at("EtaCut")){ 
+    	passCuts = passCuts && false;
+    	if(lep.type == PType::Electron) std::cout << "Electron eta cut: " << lvec.Eta() << ", passCuts = " << passCuts << std::endl;
+    }
+    else if (lvec.Pt() < stats.pmap.at("PtCut").first || lvec.Pt() > stats.pmap.at("PtCut").second){ 
+    	passCuts = passCuts && false;
+    	if(lep.type == PType::Electron) std::cout << "Electron pt cut: " << lvec.Pt() << ", passCuts = " << passCuts << std::endl;
+    }
 
     if((lep.pstats.at("Smear").bfind("MatchToGen")) && (!isData)) {   /////check
       if(matchLeptonToGen(lvec, lep.pstats.at("Smear") ,eGenPos) == TLorentzVector(0,0,0,0)) continue;
@@ -2451,8 +2457,10 @@ void Analyzer::getGoodRecoLeptons(const Lepton& lep, const CUTS ePos, const CUTS
       if(!passCuts) break;
       else if(cut == "DoDiscrByIsolation") {
         double firstIso = (stats.pmap.find("IsoSumPtCutValue") != stats.pmap.end()) ? stats.pmap.at("IsoSumPtCutValue").first : ival(ePos) - ival(CUTS::eRTau1) + 1;
+        if(lep.type == PType::Electron) std::cout << "first iso cut: " << _Electron->miniPFRelIso_all[i] << ", passCuts = " << passCuts << std::endl;
 	//if (lep.type == PType::Electron){std::cout << "firstIso: " << firstIso << std::endl;}
         double secondIso = (stats.pmap.find("IsoSumPtCutValue") != stats.pmap.end()) ? stats.pmap.at("IsoSumPtCutValue").second : stats.bfind("FlipIsolationRequirement");
+        if(lep.type == PType::Electron) std::cout << "second iso cut: " << _Electron->miniPFRelIso_all[i] << ", passCuts = " << passCuts << std::endl;
 	//if (lep.type == PType::Electron){std::cout << "secondIso: " << secondIso << std::endl;}
 	passCuts = passCuts && lep.get_Iso(i, firstIso, secondIso);
 	//if (lep.type == PType::Electron){std::cout << "pass cuts: " << passCuts << std::endl;}

--- a/src/Analyzer.h
+++ b/src/Analyzer.h
@@ -186,7 +186,7 @@ public:
   bool passCutRange(double, const std::pair<double, double>&);
   bool findCut(const std::vector<std::string>&, std::string);
 
-  void updateMet(int syst=0);
+  void selectMet(int syst=0);
   bool passMetFilters(std::string, int);
   //  void treatMuons_Met(std::string syst="orig");
   double getPileupWeight(float);

--- a/src/Analyzer.h
+++ b/src/Analyzer.h
@@ -188,7 +188,7 @@ public:
 
   void selectMet(int syst=0);
   bool passMetFilters(std::string, int);
-  //  void treatMuons_Met(std::string syst="orig");
+  void treatMuonsAsMet(int);
   double getPileupWeight(float);
   std::unordered_map<CUTS, std::vector<int>*, EnumHash> getArray();
 

--- a/src/Analyzer.h
+++ b/src/Analyzer.h
@@ -171,6 +171,7 @@ public:
   double getTauDataMCScaleFactor(int updown);
   double getWkfactor();
   double getZBoostWeight();
+  double getZBoostWeightSyst(int ud); // 06.02.20
   double getTopBoostWeight(); //01.15.19
   void setupBJetSFInfo(const PartStats&, std::string); // new function that sets up the b-tagging SF info
   double getBJetSF(CUTS, const PartStats&); //01.16.19
@@ -247,6 +248,7 @@ public:
   bool isVSample;
   bool isZsample;
   bool isWSample;
+  double boosters[3] = { }; //06.02.20
 
   std::string btagalgoname;
 

--- a/src/MET.cc
+++ b/src/MET.cc
@@ -28,8 +28,8 @@ Met::Met(TTree* _BOOM, std::string _GenName,  std::vector<std::string> _syst_nam
   }
 
   // For TreatMuonsAsNeutrinos
-  systdeltaMuMetPx.resize(syst_names.size());
-  systdeltaMuMetPy.resize(syst_names.size());
+  systdeltaMEx.resize(syst_names.size());
+  systdeltaMEy.resize(syst_names.size());
   
   // For HT, MHT
   syst_HT.resize(syst_names.size());

--- a/src/MET.cc
+++ b/src/MET.cc
@@ -27,8 +27,11 @@ Met::Met(TTree* _BOOM, std::string _GenName,  std::vector<std::string> _syst_nam
     systRawMetVec.push_back(new TLorentzVector);
   }
 
-  systdeltaMEx.resize(syst_names.size());
-  systdeltaMEy.resize(syst_names.size());
+  // For TreatMuonsAsNeutrinos
+  systdeltaMuMetPx.resize(syst_names.size());
+  systdeltaMuMetPy.resize(syst_names.size());
+  
+  // For HT, MHT
   syst_HT.resize(syst_names.size());
   syst_MHT.resize(syst_names.size());
   syst_MHTphi.resize(syst_names.size());
@@ -96,58 +99,33 @@ void Met::init(){
   t1met_py = Reco.Py();
 
   for(int i=0; i < (int) syst_names.size(); i++) {
+  	// initialize the Raw MET vector
     systRawMetVec.at(i)->SetPxPyPzE(RawMet.Px(), RawMet.Py(), RawMet.Pz(), RawMet.E());
+  
+  	// initialize the deltaMuMet vectors to zero
+    fill(systdeltaMEx.begin(), systdeltaMEx.end(), 0);
+    fill(systdeltaMEy.begin(), systdeltaMEy.end(), 0);
+
   } 
 
+  // The part below is done separately in Met::propagateUnclEnergyUncty, so this is not needed here anymore.
+/*
   for(int i=0; i < (int) syst_names.size(); i++) {
     
     if(i == Unclup) systVec.at(i)->SetPxPyPzE(MetUnclUp[0]+Reco.Px(),MetUnclUp[1]+Reco.Py(),0,sqrt(pow(MetUnclUp[0]+Reco.Px(),2)+pow(MetUnclUp[1]+Reco.Py(),2)));
     else if(i == Uncldown) systVec.at(i)->SetPxPyPzE(MetUnclDown[0]+Reco.Px(),MetUnclDown[1]+Reco.Py(),0,sqrt(pow(MetUnclDown[0]+Reco.Px(),2)+pow(MetUnclDown[1]+Reco.Py(),2)));
     else if(systVec.at(i) != nullptr) addP4Syst(Reco, i);
-    // else if(systVec.at(i) != nullptr) addP4Syst(RawMet, i);
-    
-    fill(systdeltaMEx.begin(), systdeltaMEx.end(), 0);
-    fill(systdeltaMEy.begin(), systdeltaMEy.end(), 0);
+
+    fill(systdeltaMuMetPx.begin(), systdeltaMuMetPx.end(), 0);
+    fill(systdeltaMuMetPy.begin(), systdeltaMuMetPy.end(), 0);
   }
-   cur_P=&Reco;
-   // cur_P=&RawMet;
+*/
+
+  cur_P=&Reco;
 
   // syst_HT[activeSystematic]=0.;
   // syst_MHT[activeSystematic]=0.;
   // syst_MHTphi[activeSystematic]=99.;
-}
-
-
-void Met::update(PartStats& stats, Jet& jet, int syst=0){
-  ///Calculates met from values from each file plus smearing and treating muons as neutrinos
-  if(systVec.at(syst) == nullptr) return;
-  double sumpxForMht=0;
-  double sumpyForMht=0;
-  double sumptForHt=0;
-
-  int i=0;
-  for(auto jetVec: jet) {
-    bool add = true;
-    if( (jetVec.Pt() < stats.dmap.at("JetPtForMhtAndHt")) ||
-        (abs(jetVec.Eta()) > stats.dmap.at("JetEtaForMhtAndHt")) ||
-        ( stats.bfind("ApplyJetLooseIDforMhtAndHt") &&
-          !jet.passedLooseJetID(i) ) ) add = false;
-    if(add) {
-      sumpxForMht -= jetVec.Px();
-      sumpyForMht -= jetVec.Py();
-      sumptForHt  += jetVec.Pt();
-    }
-    i++;
-  }
-  syst_HT.at(syst)=sumptForHt;
-  syst_MHT.at(syst)= sqrt( pow(sumpxForMht,2.0) + pow(sumpyForMht,2.0) );
-  syst_MHTphi.at(syst)=atan2(sumpyForMht,sumpxForMht);
-
-  systVec.at(syst)->SetPxPyPzE(systVec.at(syst)->Px()+systdeltaMEx[syst], 
-                               systVec.at(syst)->Py()+systdeltaMEy[syst], 
-                               systVec.at(syst)->Pz(), 
-                               TMath::Sqrt(pow(systVec.at(syst)->Px()+systdeltaMEx[syst],2) + pow(systVec.at(syst)->Py()+systdeltaMEy[syst],2)));
-
 }
 
 void Met::propagateJetEnergyCorr(TLorentzVector recoJet, double const& jet_pt_up, double const& jet_pt_down, std::string& systname, int syst){
@@ -247,6 +225,58 @@ void Met::propagateUnclEnergyUncty(std::string& systname, int syst){
   }
 
   systRawMetVec.at(syst)->SetPxPyPzE(met_px_unclEnshift, met_py_unclEnshift, systRawMetVec.at(syst)->Pz(), TMath::Sqrt(pow(met_px_unclEnshift,2) + pow(met_py_unclEnshift,2)));
+
+}
+
+
+//void Met::update(PartStats& stats, Jet& jet, int syst=0){
+void Met::update(int syst=0){
+
+  if(systRawMetVec.at(syst) == nullptr) return;
+  // if(systVec.at(syst) == nullptr) return;
+
+  // Treat muons as neutrinos. This is done on the systRawMetVec which is the vector that has all the JERC propagated. 
+  systRawMetVec.at(syst)->SetPxPyPzE(systRawMetVec.at(syst)->Px()+systdeltaMEx[syst], 
+                               systRawMetVec.at(syst)->Py()+systdeltaMEy[syst], 
+                               systRawMetVec.at(syst)->Pz(), 
+                               TMath::Sqrt(pow(systRawMetVec.at(syst)->Px()+systdeltaMEx[syst],2) + pow(systRawMetVec.at(syst)->Py()+systdeltaMEy[syst],2)));
+
+  //systVec.at(syst)->SetPxPyPzE(systVec.at(syst)->Px()+systdeltaMuMetPx[syst], 
+  //                             systVec.at(syst)->Py()+systdeltaMuMetPy[syst], 
+  //                             systVec.at(syst)->Pz(), 
+  //                             TMath::Sqrt(pow(systVec.at(syst)->Px()+systdeltaMuMetPx[syst],2) + pow(systVec.at(syst)->Py()+systdeltaMuMetPy[syst],2)));
+
+}
+
+void Met::calculateHtAndMHt(PartStats& stats, Jet& jet, int syst=0){
+
+  if(systRawMetVec.at(syst) == nullptr) return;
+
+  double sumpxForMht=0;
+  double sumpyForMht=0;
+  double sumptForHt=0;
+
+  // Calculates HT and MHT.
+
+  int i=0;
+  for(auto jetVec: jet){
+    bool add = true;
+    if( (jetVec.Pt() < stats.dmap.at("JetPtForMhtAndHt")) || 
+    	(abs(jetVec.Eta()) > stats.dmap.at("JetEtaForMhtAndHt")) || 
+    	(stats.bfind("ApplyJetLooseIDforMhtAndHt") && !jet.passedLooseJetID(i)) ||
+    	(stats.bfind("ApplyJetTightIDforMhtAndHt") && !jet.passedTightJetID(i)) ) add = false;
+    
+    if(add) {
+      sumpxForMht -= jetVec.Px();
+      sumpyForMht -= jetVec.Py();
+      sumptForHt  += jetVec.Pt();
+    }
+
+    i++;
+  }
+  syst_HT.at(syst)=sumptForHt;
+  syst_MHT.at(syst)= sqrt( pow(sumpxForMht,2.0) + pow(sumpyForMht,2.0) );
+  syst_MHTphi.at(syst)=atan2(sumpyForMht,sumpxForMht);
 
 }
 

--- a/src/MET.h
+++ b/src/MET.h
@@ -66,6 +66,7 @@ public:
   TLorentzVector RawMet;
   TLorentzVector DefMet;
   TLorentzVector T1Met;
+  TLorentzVector JERCorrMet;
   TLorentzVector *cur_P;
 
   std::vector<TLorentzVector* > systVec;

--- a/src/MET.h
+++ b/src/MET.h
@@ -54,11 +54,13 @@ public:
   void setMT2Mass(double);
   void setCurrentP(int);
   std::string getName() {return GenName;};
-  void update(PartStats&, Jet&, int);
+  // void update(PartStats&, Jet&, int);
+  void update(int);
 
   void propagateJetEnergyCorr(TLorentzVector recoJet, double const& jer_sf_nom, double const& jec_param, std::string& systname, int syst);  
   void propagateUnclEnergyUnctyEE(double const& delta_x_T1Jet, double const& delta_y_T1Jet, double const& delta_x_rawJet, double const& delta_y_rawJet, std::string& systname, int syst);
   void propagateUnclEnergyUncty(std::string& systname, int syst);
+  void calculateHtAndMHt(PartStats& stats, Jet& jet, int syst);
 
   TLorentzVector Reco;
   TLorentzVector RawMet;

--- a/src/Particle.cc
+++ b/src/Particle.cc
@@ -423,7 +423,7 @@ Electron::Electron(TTree* _BOOM, std::string filename, std::vector<std::string> 
   
   if( (elec1.bfind("DoDiscrBymvaID") || elec2.bfind("DoDiscrBymvaID")) ){
     SetBranch("Electron_mvaFall17V2Iso_WP80", mvaFall17V2Iso_WP80);
-    SetBranch("Electron_mvaFall17noIso_WP80", mvaFall17V2noIso_WP80);
+    SetBranch("Electron_mvaFall17V2noIso_WP80", mvaFall17V2noIso_WP80);
 
     SetBranch("Electron_mvaFall17V2Iso_WP90", mvaFall17V2Iso_WP90);
     SetBranch("Electron_mvaFall17V2noIso_WP90", mvaFall17V2noIso_WP90);

--- a/src/Particle.cc
+++ b/src/Particle.cc
@@ -380,19 +380,13 @@ Electron::Electron(TTree* _BOOM, std::string filename, std::vector<std::string> 
   tmp=elec2.dmap.at("DiscrByCBID");
   cbIDele2=tmp;
   
+  /*
   tmp=elec1.dmap.at("DiscrByHLTID");
   cbHLTIDele1=tmp;
   tmp=elec2.dmap.at("DiscrByHLTID");
   cbHLTIDele2=tmp;
-
-  /*
-  if(_BOOM->FindBranch("Electron_mvaSpring16GP")!=0){
-    std::cout<<"Electron MVA ID: Electron_mvaSpring16"<<std::endl;
-  } else{
-    std::cout<<"Electron MVA ID: Electron_mvaFall17"<<std::endl;
-  }
   */
-  
+  /*
   if((elec1.bfind("DoDiscrByIsolation") || elec2.bfind("DoDiscrByIsolation")) && _BOOM->FindBranch("Electron_mvaFall17Iso")!=0 ) {
    SetBranch("Electron_miniPFRelIso_all", miniPFRelIso_all);
    SetBranch("Electron_miniPFRelIso_chg", miniPFRelIso_chg);
@@ -410,30 +404,34 @@ Electron::Electron(TTree* _BOOM, std::string filename, std::vector<std::string> 
    SetBranch("Electron_pfRelIso03_all", pfRelIso03_all);
    SetBranch("Electron_pfRelIso03_chg", pfRelIso03_chg);
   }
+  */
 
-  if(elec1.bfind("DoDiscrByCBID") || elec2.bfind("DoDiscrByLooseID")) {
+  if((elec1.bfind("DoDiscrByIsolation") || elec2.bfind("DoDiscrByIsolation"))) {
+   SetBranch("Electron_miniPFRelIso_all", miniPFRelIso_all);
+   SetBranch("Electron_miniPFRelIso_chg", miniPFRelIso_chg);
+   SetBranch("Electron_pfRelIso03_all", pfRelIso03_all);
+   SetBranch("Electron_pfRelIso03_chg", pfRelIso03_chg);
+
+   SetBranch("Electron_mvaFall17V2Iso", mvaFall17V2Iso);
+   SetBranch("Electron_mvaFall17V2noIso", mvaFall17V2noIso);
+  }
+
+  if(elec1.bfind("DoDiscrByCBID") || elec2.bfind("DoDiscrByCBID")) {
     SetBranch("Electron_cutBased", cutBased);
-    // SetBranch("Electron_cutBased_HLTPreSel", cutBased_HLTPreSel);
   }
   
-  if(elec1.bfind("DoDiscrByHLTID") || elec2.bfind("DoDiscrByHLTID")){
-    SetBranch("Electron_cutBased_HLTPreSel", cutBased_HLTPreSel);
-  }
   
-  if((elec1.bfind("DoDiscrBymvaID") || elec2.bfind("DoDiscrByLooseID")) && _BOOM->FindBranch("Electron_mvaFall17Iso")!=0){
-    SetBranch("Electron_mvaFall17Iso_WP90", mvaIso_90);
-    SetBranch("Electron_mvaFall17noIso_WP90", mvanoIso_WP90);
-    SetBranch("Electron_mvaFall17Iso_WP80", mvaIso_80);
-    SetBranch("Electron_mvaFall17noIso_WP80", mvanoIso_WP80);
-    SetBranch("Electron_mvaFall17Iso_WPL", mvaIso_WPL);
-    SetBranch("Electron_mvaFall17noIso_WPL", mvanoIso_WPL);
-  }
+  if( (elec1.bfind("DoDiscrBymvaID") || elec2.bfind("DoDiscrBymvaID")) ){
+    SetBranch("Electron_mvaFall17V2Iso_WP80", mvaFall17V2Iso_WP80);
+    SetBranch("Electron_mvaFall17noIso_WP80", mvaFall17V2noIso_WP80);
 
-  if((elec1.bfind("DoDiscrBymvaID") || elec2.bfind("DoDiscrByLooseID")) && _BOOM->FindBranch("Electron_mvaSpring16GP_WP90")!=0){
-    SetBranch("Electron_mvaSpring16GP_WP90", mvaGP_90);
-    SetBranch("Electron_mvaSpring16GP_WP80", mvaGP_80);
-    SetBranch("Electron_mvaSpring16HZZ_WPL", mvaHZZ_WPL);
-    SetBranch("Electron_mvaTTH", mvaTTH); 
+    SetBranch("Electron_mvaFall17V2Iso_WP90", mvaFall17V2Iso_WP90);
+    SetBranch("Electron_mvaFall17V2noIso_WP90", mvaFall17V2noIso_WP90);
+
+    SetBranch("Electron_mvaFall17V2Iso_WPL", mvaFall17V2Iso_WPL);
+    SetBranch("Electron_mvaFall17V2noIso_WPL", mvaFall17V2noIso_WPL);
+
+    SetBranch("Electron_mvaTTH", mvaTTH);
   }
 
   if(elec1.bfind("DoDiscrByHEEPID") || elec2.bfind("DoDiscrByHEEPID")) {

--- a/src/Particle.h
+++ b/src/Particle.h
@@ -247,27 +247,19 @@ public:
   // Electron MVA ID fall 2017 
   float miniPFRelIso_all[MAXINDEX];
   float miniPFRelIso_chg[MAXINDEX];
-  float mvaFall17Iso[MAXINDEX];
-  float mvaFall17noIso[MAXINDEX];
+  float mvaFall17V2Iso[MAXINDEX];
+  float mvaFall17V2Iso_WP80[MAXINDEX];
+  float mvaFall17V2Iso_WP90[MAXINDEX];
+  float mvaFall17V2Iso_WPL[MAXINDEX];
+  float mvaFall17V2noIso[MAXINDEX];
+  float mvaFall17V2noIso_WP80[MAXINDEX];
+  float mvaFall17V2noIso_WP90[MAXINDEX];
+  float mvaFall17V2noIso_WPL[MAXINDEX];
+  bool mvaTTH[MAXINDEX];
   float pfRelIso03_all[MAXINDEX];
   float pfRelIso03_chg[MAXINDEX];
   int cutBased[MAXINDEX];
-  bool cutBased_HLTPreSel[MAXINDEX];
-  bool mvaIso_90[MAXINDEX];
-  bool mvanoIso_WP90[MAXINDEX];
-  bool mvaIso_80[MAXINDEX];
-  bool mvanoIso_WP80[MAXINDEX];
-  bool mvaIso_WPL[MAXINDEX];
-  bool mvanoIso_WPL[MAXINDEX];
   bool isPassHEEPId[MAXINDEX];
-
-  // Electron MVA ID spring 2016
-  float mvaSpring16GP[MAXINDEX];
-  float mvaSpring16HZZ[MAXINDEX];
-  bool mvaGP_90[MAXINDEX];
-  bool mvaGP_80[MAXINDEX];
-  bool mvaHZZ_WPL[MAXINDEX];
-  bool mvaTTH[MAXINDEX];
 
 };
 


### PR DESCRIPTION
Changed the names of electron isolation branches to the most up-to-date ones for NanoAODv6. The function treatMuonsAsMet is brought back with an additional option to treat only one of the muons as MET. A new function for Z-boost weights systematics is also implemented.