### PR TITLE
Fix a bug with calculating minDeltaPhiMet in `Analyzer::fill_Folder`.

### DIFF
--- a/src/Analyzer.cc
+++ b/src/Analyzer.cc
@@ -5547,10 +5547,6 @@ void Analyzer::fill_Folder(std::string group, const int max, Histogramer &ihisto
         histAddVal(deltaPhiMet, "AbsDPhiMet");
         histAddVal(normPhi(part->p4(it).Phi() - _MET->phi()), "DPhiMet");
 
-        if(deltaPhiMet < minDeltaPhiMet){
-          minDeltaPhiMet = deltaPhiMet;
-        }
-
         float cosDPhiJetMet = cos(normPhi(part->p4(it).Phi() - _MET->phi()));
         float jetptmetproj_plus = 0.0, jetptmetproj_minus = 0.0;
 
@@ -5589,7 +5585,6 @@ void Analyzer::fill_Folder(std::string group, const int max, Histogramer &ihisto
 
     if(part->type == PType::Jet){
       // std::cout << "the minimum minDeltaPhiMet = " << minDeltaPhiMet << std::endl;
-      histAddVal(minDeltaPhiMet, "MinAbsDPhiMet"); // minimum |deltaPhi(jet, MET)|
 
       if(index_minjmetdphi > -1){
         histAddVal(_Jet->pt(index_minjmetdphi), "MinAbsDPhiMetPt");


### PR DESCRIPTION
This PR is a minor fix about the QCD event rejection discriminant in the `Analyzer::fill_Folder`. First, there are two if-statements to compare `minDeltaPhiMet` with `deltaPhiMet` in the `Analyzer::fill_Folder`. In the first place, `index_minjmetdphi`, which is the index of the jet with `minDeltaPhiMet`, is not updated. As a result, it is skipped to fill all histograms related to `minDeltaPhiMet`. So, I removed the first if-statement. Also, `MinAbsDPhiMet` histograms are being filled twice. So, I fixed this.